### PR TITLE
S0003 string datatype

### DIFF
--- a/Source/HL7.Net/Core/EncodingDetails.cs
+++ b/Source/HL7.Net/Core/EncodingDetails.cs
@@ -20,8 +20,20 @@
 ///   Separates adjacent subcomponents of data fields.
 /// </param>
 internal record EncodingDetails(
-      Char FieldSeparator,
-      Char ComponentSeparator,
-      Char RepetitionSeparator,
-      Char EscapeCharacter,
-      Char SubComponentSeparator);
+   Char FieldSeparator,
+   Char ComponentSeparator,
+   Char RepetitionSeparator,
+   Char EscapeCharacter,
+   Char SubComponentSeparator)
+{
+   public IEnumerable<Char> AllSeparators 
+   {
+      get
+      {
+         yield return ComponentSeparator;
+         yield return RepetitionSeparator;
+         yield return SubComponentSeparator;
+         yield return EscapeCharacter;
+      }
+   }
+}

--- a/Source/HL7.Net/Core/EncodingDetails.cs
+++ b/Source/HL7.Net/Core/EncodingDetails.cs
@@ -30,10 +30,22 @@ internal record EncodingDetails(
    {
       get
       {
+         yield return FieldSeparator;
          yield return ComponentSeparator;
          yield return RepetitionSeparator;
          yield return SubComponentSeparator;
          yield return EscapeCharacter;
       }
    }
+
+   /// <summary>
+   ///   <see cref="EncodingDetails"/> instance using the default encoding
+   ///   characters recommended by the HL7 specification.
+   /// </summary>
+   public static readonly EncodingDetails DefaultEncodingDetails = new EncodingDetails(
+         DefaultSeparators.FieldSeparator,
+         DefaultSeparators.ComponentSeparator,
+         DefaultSeparators.RepetitionSeparator,
+         DefaultSeparators.EscapeCharacter,
+         DefaultSeparators.SubComponentSeparator);
 }

--- a/Source/HL7.Net/Core/FieldEnumerator.cs
+++ b/Source/HL7.Net/Core/FieldEnumerator.cs
@@ -6,13 +6,32 @@
 /// </summary>
 public ref struct FieldEnumerator
 {
+   private readonly Char _escapeCharacter;
    private readonly Char _separator;
    private ReadOnlySpan<Char> _text;
 
-   public FieldEnumerator(ReadOnlySpan<Char> text, Char separator)
+   /// <summary>
+   ///   Initialize a new <see cref="FieldEnumerator"/> object.
+   /// </summary>
+   /// <param name="text">
+   ///   The span of characters to process.
+   /// </param>
+   /// <param name="separator">
+   ///   The character used to indicate the end of a field and the start of 
+   ///   another.
+   /// </param>
+   /// <param name="escapeCharacter">
+   ///   The character used to "escape" the separator character and allow it to
+   ///   be included in a field instead of starting a new field.
+   /// </param>
+   internal FieldEnumerator(
+      ReadOnlySpan<Char> text, 
+      Char separator,
+      Char escapeCharacter)
    {
       _text = text;
       _separator = separator;
+      _escapeCharacter = escapeCharacter;
       Current = default;
    }
 
@@ -48,6 +67,12 @@ public ref struct FieldEnumerator
       }
 
       var index = span.IndexOf(_separator);
+
+      // Skip over escaped separator characters.
+      while (index > 0 && span[index - 1] == _escapeCharacter)
+      {
+         index = span.IndexOf(_separator, index + 1);
+      }
 
       // Handle only one line remaining.
       if (index == -1)

--- a/Source/HL7.Net/Core/FieldSeparatorField.cs
+++ b/Source/HL7.Net/Core/FieldSeparatorField.cs
@@ -46,8 +46,7 @@ public sealed record FieldSeparatorField
          log.LogFatalError(
             $"Missing required field - {fieldSpecification.FieldName}",
             lineNumber,
-            fieldSpecification.SegmentID,
-            fieldSpecification.Sequence);
+            fieldSpecification);
          return new FieldSeparatorField('\0', null, FieldPresence.NotPresent);
       }
 

--- a/Source/HL7.Net/Core/FieldSpecification.cs
+++ b/Source/HL7.Net/Core/FieldSpecification.cs
@@ -36,5 +36,5 @@ internal record FieldSpecification(
    Optionality Optionality,
    Repetition Repetition)
 {
-   public String FieldDescription { get; init; } = $"{SegmentID}.{Sequence}/{FieldName}";
+   public String FieldDescription { get; private init; } = $"{SegmentID}.{Sequence}/{FieldName}";
 }

--- a/Source/HL7.Net/Core/FieldSpecification.cs
+++ b/Source/HL7.Net/Core/FieldSpecification.cs
@@ -34,4 +34,7 @@ internal record FieldSpecification(
    Int32 Length,
    HL7Datatype Datatype,
    Optionality Optionality,
-   Repetition Repetition);
+   Repetition Repetition)
+{
+   public String FieldDescription { get; init; } = $"{SegmentID}.{Sequence}/{FieldName}";
+}

--- a/Source/HL7.Net/Core/GeneralConstants.cs
+++ b/Source/HL7.Net/Core/GeneralConstants.cs
@@ -1,0 +1,6 @@
+﻿namespace HL7.Net.Core;
+
+internal static class GeneralConstants
+{
+   public const String PresentButNullValue = "\"\"";
+}

--- a/Source/HL7.Net/Core/LogEntry.cs
+++ b/Source/HL7.Net/Core/LogEntry.cs
@@ -6,14 +6,15 @@
 /// <param name="LogLevel">
 ///   The level or severity of this entry.
 /// </param>
-/// <param name="message">
+/// <param name="Message">
 ///   Descriptive text for this entry.
 /// </param>
-/// <param name="lineNumber">
+/// <param name="LineNumber">
 ///   The line number in the HL7 text associated with this entry.
 /// </param>
-/// <param name="segmentID">
-///   Optional. The segment ID of the segment associated with this entry.
+/// <param name="FieldDescriptor">
+///   Optional. The field description in the form 
+///   SegmentID.Sequence{[Index]}{.ComponentSequence}/FieldName{.ComponentFieldName}
 /// </param>
 /// <param name="fieldNumber">
 ///   Optional. The field number of the segment field associated with this 
@@ -24,8 +25,7 @@
 /// </param>
 public record LogEntry(
    LogLevel LogLevel,
-   String message,
-   Int32 lineNumber,
-   String? segmentID = null,
-   Int32? fieldNumber = null,
-   String? rawData = null);
+   String Message,
+   Int32 LineNumber,
+   String? FieldDescription = null,
+   String? RawData = null);

--- a/Source/HL7.Net/Core/ProcessingLog.cs
+++ b/Source/HL7.Net/Core/ProcessingLog.cs
@@ -27,51 +27,76 @@ public class ProcessingLog : IEnumerable<LogEntry>
    /// </summary>
    public IEnumerator<LogEntry> GetEnumerator() => _logs.GetEnumerator();
 
-   public void LogInformation(
+   internal void LogError(
       String message,
       Int32 lineNumber,
-      String? segmentID = null,
-      Int32? fieldNumber = null,
-      String? rawData = null)
-      => _logs.Add(new LogEntry(LogLevel.Information, message, lineNumber, segmentID, fieldNumber, rawData));
-
-   public void LogError(
-      String message,
-      Int32 lineNumber,
-      String? segmentID = null,
-      Int32? fieldNumber = null,
+      FieldSpecification? fieldSpecification = null,
       String? rawData = null)
    {
-      _logs.Add(new LogEntry(LogLevel.Error, message, lineNumber, segmentID, fieldNumber, rawData));
-      if ((Int32) HighestLogLevel < (Int32) LogLevel.Error)
+      _logs.Add(new LogEntry(LogLevel.Error, message, lineNumber, fieldSpecification?.FieldDescription, rawData));
+      if (HighestLogLevel < LogLevel.Error)
       {
          HighestLogLevel = LogLevel.Error;
       }
    }
 
-   public void LogFatalError(
+   internal void LogFatalError(
       String message,
       Int32 lineNumber,
-      String? segmentID = null,
-      Int32? fieldNumber = null,
+      FieldSpecification? fieldSpecification = null,
       String? rawData = null)
    {
-      _logs.Add(new LogEntry(LogLevel.FatalError, message, lineNumber, segmentID, fieldNumber, rawData));
-      if ((Int32)HighestLogLevel < (Int32)LogLevel.FatalError)
+      _logs.Add(new LogEntry(LogLevel.FatalError, message, lineNumber, fieldSpecification?.FieldDescription, rawData));
+      if (HighestLogLevel < LogLevel.FatalError)
       {
          HighestLogLevel = LogLevel.FatalError;
       }
    }
 
-   public void LogWarning(
+   internal void LogFieldNotPresent(Int32 lineNumber, FieldSpecification fieldSpecification)
+   {
+      String message;
+      if (fieldSpecification.Optionality == Optionality.Required)
+      {
+         message = String.Format(Messages.LogRequiredFieldNotPresent, fieldSpecification.FieldDescription);
+         LogError(message, lineNumber, fieldSpecification);
+         return;
+      }
+
+      message = String.Format(Messages.LogFieldNotPresent, fieldSpecification.FieldDescription);
+      LogInformation(message, lineNumber, fieldSpecification);
+   }
+
+   internal void LogFieldPresent(
+      Int32 lineNumber,
+      FieldSpecification fieldSpecification,
+      ReadOnlySpan<Char> fieldContents)
+   {
+      var message = String.Format(Messages.LogFieldPresent, fieldSpecification.FieldDescription);
+      LogInformation(message, lineNumber, fieldSpecification, fieldContents.ToString());
+   }
+
+   internal void LogFieldPresentButNull(Int32 lineNumber, FieldSpecification fieldSpecification)
+   {
+      var message = String.Format(Messages.LogFieldPresentButNull, fieldSpecification.FieldDescription);
+      LogInformation(message, lineNumber, fieldSpecification, "\"\"");
+   }
+
+   internal void LogInformation(
       String message,
       Int32 lineNumber,
-      String? segmentID = null,
-      Int32? fieldNumber = null,
+      FieldSpecification? fieldSpecification = null,
+      String? rawData = null)
+      => _logs.Add(new LogEntry(LogLevel.Information, message, lineNumber, fieldSpecification?.FieldDescription, rawData));
+
+   internal void LogWarning(
+      String message,
+      Int32 lineNumber,
+      FieldSpecification? fieldSpecification = null,
       String? rawData = null)
    {
-      _logs.Add(new LogEntry(LogLevel.Warning, message, lineNumber, segmentID, fieldNumber, rawData));
-      if ((Int32)HighestLogLevel < (Int32)LogLevel.Warning)
+      _logs.Add(new LogEntry(LogLevel.Warning, message, lineNumber, fieldSpecification?.FieldDescription, rawData));
+      if (HighestLogLevel < LogLevel.Warning)
       {
          HighestLogLevel = LogLevel.Warning;
       }

--- a/Source/HL7.Net/Core/SpanExtensions.cs
+++ b/Source/HL7.Net/Core/SpanExtensions.cs
@@ -1,8 +1,31 @@
-﻿namespace HL7.Net.Core;
+﻿using System.Text;
+
+namespace HL7.Net.Core;
 
 public static class SpanExtensions
 {
-   public static FieldEnumerator ToFields(this ReadOnlySpan<Char> span, Char separator) => new(span, separator);
+   /// <summary>
+   ///   Get an enumerator that breaks a span into a series of fields separated
+   ///   by the <paramref name="separator"/> character. 
+   /// </summary>
+   /// <param name="span">
+   ///   The span of characters to separate into fields.
+   /// </param>
+   /// <param name="separator">
+   ///   The character used to indicate the end of a field and the start of 
+   ///   another.
+   /// </param>
+   /// <param name="escapeCharacter">
+   ///   The character used to "escape" the separator character and allow it to
+   ///   be included in a field instead of starting a new field.
+   /// </param>
+   /// <returns>
+   ///   A <see cref="FieldEnumerator"/> object.
+   /// </returns>
+   public static FieldEnumerator ToFields(
+      this ReadOnlySpan<Char> span, 
+      Char separator,
+      Char escapeCharacter) => new(span, separator, escapeCharacter);
 
    public static LineEnumerator ToLines(this ReadOnlySpan<Char> span) => new(span);
 
@@ -25,18 +48,30 @@ public static class SpanExtensions
       this ReadOnlySpan<Char> span,
       EncodingDetails encodingDetails)
    {
-      var decoded = span.ToString();
-      foreach (var ch in encodingDetails.AllSeparators)
+      var index = span.IndexOf(encodingDetails.EscapeCharacter);
+      if (index == -1)
       {
-         if (span.IndexOf(ch) != -1)
-         {
-            var escapedSequence = $"{encodingDetails.EscapeCharacter}{ch}";
-            var replaceWith = new String(ch, 1);
-            decoded = decoded.Replace(escapedSequence, replaceWith);
-         }
+         return span.ToString();
       }
+
+      var sb = new StringBuilder();
+      while(index != -1)
+      {
+         sb.Append(span[..index]);              // Everything preceding the escape character
+         if (index < span.Length - 1)
+         {
+            sb.Append(span[index + 1]);         // The escaped character
+            span = span[(index + 2)..];         // Start again after the escaped character
+         }
+         else
+         {
+            span = ReadOnlySpan<Char>.Empty;    // Last character was the escape character
+         }
+         index = span.IndexOf(encodingDetails.EscapeCharacter);
+      }
+      sb.Append(span);                          // The remainder
       
-      return decoded;
+      return sb.ToString();
    }
 
    /// <summary>

--- a/Source/HL7.Net/Core/SpanExtensions.cs
+++ b/Source/HL7.Net/Core/SpanExtensions.cs
@@ -7,6 +7,41 @@ public static class SpanExtensions
    public static FieldEnumerator ToFields(this ReadOnlySpan<Char> span, Char separator) => new(span, separator);
 
    /// <summary>
+   ///   Given a span of characters, which may or may not contain escape
+   ///   sequences, return a string where escaped characters are replaced by
+   ///   their un-escaped value. If the span does not contain escape sequences
+   ///   then the entire span is returned as a string.
+   /// </summary>
+   /// <param name="span">
+   ///   The span of characters to decode.
+   /// </param>
+   /// <param name="encodingDetails">
+   ///   Specifies how encoding of a segment or composite field is handled.
+   /// </param>
+   /// <returns>
+   ///   The decoded contents of the input <paramref name="span"/>.
+   /// </returns>
+   internal static String GetDecodedString(
+      this ReadOnlySpan<Char> span,
+      EncodingDetails encodingDetails)
+   {
+      var raw = span.ToString();
+      String decoded = null!;
+      foreach (var ch in encodingDetails.AllSeparators)
+      {
+         if (span.IndexOf(ch) != -1)
+         {
+            var escapedSequence = $"{encodingDetails.EscapeCharacter}{ch}";
+            var replaceWith = new String(ch, 1);
+            decoded ??= span.ToString();
+            decoded = decoded.Replace(escapedSequence, replaceWith);
+         }
+      }
+      
+      return decoded ??= raw;
+   }
+
+   /// <summary>
    ///   Gonna need this to handle escaped delimiters in FieldEnumerator
    /// </summary>
    /// <param name="aSpan"></param>

--- a/Source/HL7.Net/Core/SpanExtensions.cs
+++ b/Source/HL7.Net/Core/SpanExtensions.cs
@@ -2,9 +2,9 @@
 
 public static class SpanExtensions
 {
-   public static LineEnumerator ToLines(this ReadOnlySpan<Char> span) => new(span);
-
    public static FieldEnumerator ToFields(this ReadOnlySpan<Char> span, Char separator) => new(span, separator);
+
+   public static LineEnumerator ToLines(this ReadOnlySpan<Char> span) => new(span);
 
    /// <summary>
    ///   Given a span of characters, which may or may not contain escape
@@ -25,20 +25,18 @@ public static class SpanExtensions
       this ReadOnlySpan<Char> span,
       EncodingDetails encodingDetails)
    {
-      var raw = span.ToString();
-      String decoded = null!;
+      var decoded = span.ToString();
       foreach (var ch in encodingDetails.AllSeparators)
       {
          if (span.IndexOf(ch) != -1)
          {
             var escapedSequence = $"{encodingDetails.EscapeCharacter}{ch}";
             var replaceWith = new String(ch, 1);
-            decoded ??= span.ToString();
             decoded = decoded.Replace(escapedSequence, replaceWith);
          }
       }
       
-      return decoded ??= raw;
+      return decoded;
    }
 
    /// <summary>

--- a/Source/HL7.Net/Core/StringField.cs
+++ b/Source/HL7.Net/Core/StringField.cs
@@ -57,17 +57,22 @@ public sealed record StringField
          return StringField.PresentButNull;
       }
 
-      var raw = fieldContents.ToString();
-      if (raw.Length > fieldSpecification.Length)
+      var decoded = fieldContents.GetDecodedString(encodingDetails);
+      if (decoded.Length > fieldSpecification.Length)
       {
+         var message = String.Format(
+            Messages.LogFieldPresentButTruncated,
+            fieldSpecification.FieldDescription,
+            fieldSpecification.Length);
          log.LogWarning(
-            $"String value truncated to field maximum length ({fieldSpecification.Length})",
+            message,
             lineNumber,
             fieldSpecification,
-            raw);
+            fieldContents.ToString());
+         return new StringField(decoded[..fieldSpecification.Length]);
       }
-      return new StringField(raw.Length > fieldSpecification.Length 
-         ? raw[..fieldSpecification.Length] 
-         : raw);
+
+      log.LogFieldPresent(lineNumber, fieldSpecification, fieldContents);
+      return new StringField(decoded);
    }
 }

--- a/Source/HL7.Net/Messages.Designer.cs
+++ b/Source/HL7.Net/Messages.Designer.cs
@@ -97,6 +97,60 @@ namespace HL7.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Field {0} has duplicate encoding character {1}.
+        /// </summary>
+        internal static string LogDuplicateEncodingCharacter {
+            get {
+                return ResourceManager.GetString("LogDuplicateEncodingCharacter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field {0} has invalid length.
+        /// </summary>
+        internal static string LogFieldInvalidLength {
+            get {
+                return ResourceManager.GetString("LogFieldInvalidLength", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field {0} is not present.
+        /// </summary>
+        internal static string LogFieldNotPresent {
+            get {
+                return ResourceManager.GetString("LogFieldNotPresent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field {0} is present.
+        /// </summary>
+        internal static string LogFieldPresent {
+            get {
+                return ResourceManager.GetString("LogFieldPresent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field {0} is present but null.
+        /// </summary>
+        internal static string LogFieldPresentButNull {
+            get {
+                return ResourceManager.GetString("LogFieldPresentButNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required field {0} is not present.
+        /// </summary>
+        internal static string LogRequiredFieldNotPresent {
+            get {
+                return ResourceManager.GetString("LogRequiredFieldNotPresent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value is null, String.Empty or all whitespace characters.
         /// </summary>
         internal static string StringValueIsNullOrWhiteSpace {

--- a/Source/HL7.Net/Messages.Designer.cs
+++ b/Source/HL7.Net/Messages.Designer.cs
@@ -142,6 +142,15 @@ namespace HL7.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Field {0} is present but was truncated to field max length of {1}.
+        /// </summary>
+        internal static string LogFieldPresentButTruncated {
+            get {
+                return ResourceManager.GetString("LogFieldPresentButTruncated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Required field {0} is not present.
         /// </summary>
         internal static string LogRequiredFieldNotPresent {

--- a/Source/HL7.Net/Messages.resx
+++ b/Source/HL7.Net/Messages.resx
@@ -129,6 +129,24 @@
   <data name="InvalidRepetitionSpecification" xml:space="preserve">
     <value>Value is not 'N', 'Y' or a integer greater than one (1)</value>
   </data>
+  <data name="LogDuplicateEncodingCharacter" xml:space="preserve">
+    <value>Field {0} has duplicate encoding character {1}</value>
+  </data>
+  <data name="LogFieldInvalidLength" xml:space="preserve">
+    <value>Field {0} has invalid length</value>
+  </data>
+  <data name="LogFieldNotPresent" xml:space="preserve">
+    <value>Field {0} is not present</value>
+  </data>
+  <data name="LogFieldPresent" xml:space="preserve">
+    <value>Field {0} is present</value>
+  </data>
+  <data name="LogFieldPresentButNull" xml:space="preserve">
+    <value>Field {0} is present but null</value>
+  </data>
+  <data name="LogRequiredFieldNotPresent" xml:space="preserve">
+    <value>Required field {0} is not present</value>
+  </data>
   <data name="StringValueIsNullOrWhiteSpace" xml:space="preserve">
     <value>Value is null, String.Empty or all whitespace characters</value>
   </data>

--- a/Source/HL7.Net/Messages.resx
+++ b/Source/HL7.Net/Messages.resx
@@ -144,6 +144,9 @@
   <data name="LogFieldPresentButNull" xml:space="preserve">
     <value>Field {0} is present but null</value>
   </data>
+  <data name="LogFieldPresentButTruncated" xml:space="preserve">
+    <value>Field {0} is present but was truncated to field max length of {1}</value>
+  </data>
   <data name="LogRequiredFieldNotPresent" xml:space="preserve">
     <value>Required field {0} is not present</value>
   </data>

--- a/Source/HL7.Net/V2Point2/EventTypeSegment.cs
+++ b/Source/HL7.Net/V2Point2/EventTypeSegment.cs
@@ -56,7 +56,9 @@ public class EventTypeSegment : ISegment
 
       // Enumerate the fields and skip over the first field which contains the
       // segment ID.
-      var fieldEnumerator = segmentText.ToFields(encodingDetails.FieldSeparator);
+      var fieldEnumerator = segmentText.ToFields(
+         encodingDetails.FieldSeparator,
+         encodingDetails.EscapeCharacter);
       fieldEnumerator.MoveNext();
 
       segment.EventTypeCode = StringField.Parse(

--- a/Source/HL7.Net/V2Point2/HL7Message.cs
+++ b/Source/HL7.Net/V2Point2/HL7Message.cs
@@ -83,8 +83,7 @@ public sealed class HL7Message : IHL7Message
    {
       log.LogError(
          "Unrecognized segment ID",
-         lineNumber,
-         segmentID: segmentID);
+         lineNumber);
 
       return null!;
    }

--- a/Source/HL7.Net/V2Point2/MessageHeaderSegment.cs
+++ b/Source/HL7.Net/V2Point2/MessageHeaderSegment.cs
@@ -143,7 +143,9 @@ public class MessageHeaderSegment : ISegment
 
       // Enumerate the fields and skip over the first field which contains the
       // segment ID.
-      var fieldEnumerator = segmentText.ToFields(segment.FieldSeparator);
+      var fieldEnumerator = segmentText.ToFields(
+         segment.FieldSeparator,
+         '\0');
       fieldEnumerator.MoveNext();
 
       segment.EncodingCharacters = EncodingCharactersField.Parse(

--- a/Source/HL7.Net/V2Point2/NextOfKinSegment.cs
+++ b/Source/HL7.Net/V2Point2/NextOfKinSegment.cs
@@ -106,7 +106,9 @@ public class NextOfKinSegment : ISegment
 
       // Enumerate the fields and skip over the first field which contains the
       // segment ID.
-      var fieldEnumerator = segmentText.ToFields(encodingDetails.FieldSeparator);
+      var fieldEnumerator = segmentText.ToFields(
+         encodingDetails.FieldSeparator,
+         encodingDetails.EscapeCharacter);
       fieldEnumerator.MoveNext();
 
       segment.SetID = StringField.Parse(

--- a/Source/HL7.Net/V2Point2/PatientIdentificationSegment.cs
+++ b/Source/HL7.Net/V2Point2/PatientIdentificationSegment.cs
@@ -196,7 +196,9 @@ public class PatientIdentificationSegment : ISegment
 
       // Enumerate the fields and skip over the first field which contains the
       // segment ID.
-      var fieldEnumerator = segmentText.ToFields(encodingDetails.FieldSeparator);
+      var fieldEnumerator = segmentText.ToFields(
+         encodingDetails.FieldSeparator,
+         encodingDetails.EscapeCharacter);
       fieldEnumerator.MoveNext();
 
       segment.SetID = StringField.Parse(

--- a/Source/HL7.Net/V2Point2/PatientVisitSegment.cs
+++ b/Source/HL7.Net/V2Point2/PatientVisitSegment.cs
@@ -349,7 +349,9 @@ public class PatientVisitSegment : ISegment
 
       // Enumerate the fields and skip over the first field which contains the
       // segment ID.
-      var fieldEnumerator = segmentText.ToFields(encodingDetails.FieldSeparator);
+      var fieldEnumerator = segmentText.ToFields(
+         encodingDetails.FieldSeparator, 
+         encodingDetails.EscapeCharacter);
       fieldEnumerator.MoveNext();
 
       segment.SetID = StringField.Parse(

--- a/Tests/HL7.Net.Tests.Unit/Core/ProcessingLogTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/ProcessingLogTests.cs
@@ -1,0 +1,630 @@
+﻿namespace HL7.Net.Tests.Unit.Core;
+
+public class ProcessingLogTests
+{
+   private static readonly FieldSpecification _fieldSpecification = new(
+      "TST",
+      1,
+      "Test Field",
+      15,
+      HL7Datatype.ST_String,
+      Optionality.Optional,
+      "N");
+   private const Int32 _lineNumber = 42;
+
+   #region Internal Constructor Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_Constructor_ShouldCreateEmptyLog()
+   {
+      // Act.
+      var sut = new ProcessingLog();
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Should().BeEmpty();
+      sut.Count.Should().Be(0);
+      sut.HighestLogLevel.Should().Be(LogLevel.Information);
+   }
+
+   #endregion
+
+   #region Inherent Enumerable Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_InherentEnumerable_ShouldReturnEmpty_WhenLogIsEmpty()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      // Act.
+      var entries = sut.ToList();
+
+      // Assert.
+      entries.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void ProcessingLog_InherentEnumerable_ShouldReturnExpectedItems_WhenLogIsPopulated()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+      sut.LogInformation("Information", 1);
+      sut.LogWarning("Warning", 2);
+      sut.LogError("Error", 3);
+      sut.LogFatalError("FatalError", 4);
+
+      var expected = new List<LogEntry>
+      {
+         new LogEntry(LogLevel.Information, "Information", 1),
+         new LogEntry(LogLevel.Warning, "Warning", 2),
+         new LogEntry(LogLevel.Error, "Error", 3),
+         new LogEntry(LogLevel.FatalError, "FatalError", 4),
+      };
+
+      // Assert.
+      sut.Should().Equal(expected);
+   }
+
+   #endregion
+
+   #region Count Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData(0)]
+   [InlineData(1)]
+   [InlineData(5)]
+   public void ProcessingLog_Count_ShouldReflectNumberOfLogEntries(Int32 numItems)
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      // Act.
+      for(var i = 0; i < numItems; i++)
+      {
+         sut.LogInformation("This is a test", i);
+      }
+
+      // Assert.
+      sut.Count.Should().Be(numItems);
+      sut.Should().HaveCount(numItems);
+   }
+
+   #endregion
+
+   #region HighestLogLevel Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_HighestLogLevel_ShouldBeInformation_WhenLogIsEmpty()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      // Assert.
+      sut.HighestLogLevel.Should().Be(LogLevel.Information);
+   }
+
+   [Fact]
+   public void ProcessingLog_HighestLogLevel_ShouldBeWarning_WhenWarningIsTheMostSevereEntry()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      // Act.
+      sut.LogInformation("Information", 1);
+      sut.LogWarning("Warning", 2);
+      sut.LogInformation("Information", 3);
+
+      // Assert.
+      sut.HighestLogLevel.Should().Be(LogLevel.Warning);
+   }
+
+   [Fact]
+   public void ProcessingLog_HighestLogLevel_ShouldBeError_WhenErrorIsTheMostSevereEntry()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      // Act.
+      sut.LogInformation("Information", 1);
+      sut.LogWarning("Warning", 2);
+      sut.LogError("Error", 3);
+      sut.LogWarning("Warning", 4);
+      sut.LogInformation("Information", 5);
+
+      // Assert.
+      sut.HighestLogLevel.Should().Be(LogLevel.Error);
+   }
+
+   [Fact]
+   public void ProcessingLog_HighestLogLevel_ShouldBeFatalError_WhenFatalErrorIsTheMostSevereEntry()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      // Act.
+      sut.LogInformation("Information", 1);
+      sut.LogWarning("Warning", 2);
+      sut.LogError("Error", 3);
+      sut.LogFatalError("Fatal Error", 4);
+      sut.LogError("Error", 5);
+      sut.LogWarning("Warning", 6);
+      sut.LogInformation("Information", 7);
+
+      // Assert.
+      sut.HighestLogLevel.Should().Be(LogLevel.FatalError);
+   }
+
+   #endregion
+
+   #region LogError Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_LogError_ShouldAddExpectedEntry_WhenOnlyRequiredParametersAreIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+
+      var expectedEntry = new LogEntry(LogLevel.Error, message, _lineNumber);
+
+      // Act.
+      sut.LogError(message, _lineNumber);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogError_ShouldAddExpectedEntry_WhenFieldSpecificationIsIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Error, 
+         message, 
+         _lineNumber, 
+         _fieldSpecification.FieldDescription);
+
+      // Act.
+      sut.LogError(message, _lineNumber, _fieldSpecification);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogError_ShouldAddExpectedEntry_WhenRawDataIsIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         RawData: rawData);
+
+      // Act.
+      sut.LogError(message, _lineNumber, rawData: rawData);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogError_ShouldAddExpectedEntry_WhenAllParametersAreIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         rawData);
+
+      // Act.
+      sut.LogError(message, _lineNumber, _fieldSpecification, rawData);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   #endregion
+
+   #region LogFatalError Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_LogFatalError_ShouldAddExpectedEntry_WhenOnlyRequiredParametersAreIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+
+      var expectedEntry = new LogEntry(LogLevel.FatalError, message, _lineNumber);
+
+      // Act.
+      sut.LogFatalError(message, _lineNumber);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogFatalError_ShouldAddExpectedEntry_WhenFieldSpecificationIsIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.FatalError,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription);
+
+      // Act.
+      sut.LogFatalError(message, _lineNumber, _fieldSpecification);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogFatalError_ShouldAddExpectedEntry_WhenRawDataIsIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.FatalError,
+         message,
+         _lineNumber,
+         RawData: rawData);
+
+      // Act.
+      sut.LogFatalError(message, _lineNumber, rawData: rawData);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogFatalError_ShouldAddExpectedEntry_WhenAllParametersAreIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.FatalError,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         rawData);
+
+      // Act.
+      sut.LogFatalError(message, _lineNumber, _fieldSpecification, rawData);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   #endregion
+
+   #region LogFieldNotPresent Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_LogNotPresent_ShouldAddExpectedEntry_WhenFieldIsOptional()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = String.Format(Messages.LogFieldNotPresent, _fieldSpecification.FieldDescription);
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription);
+
+      // Act.
+      sut.LogFieldNotPresent(_lineNumber, _fieldSpecification);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogNotPresent_ShouldAddExpectedEntry_WhenFieldIsRequired()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var fieldSpecification = _fieldSpecification with { Optionality = Optionality.Required };
+      var message = String.Format(Messages.LogRequiredFieldNotPresent, fieldSpecification.FieldDescription);
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription);
+
+      // Act.
+      sut.LogFieldNotPresent(_lineNumber, fieldSpecification);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   #endregion
+
+   #region LogFieldPresent Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_LogFieldPresent_ShouldAddExpectedEntry()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = String.Format(Messages.LogFieldPresent, _fieldSpecification.FieldDescription);
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         rawData);
+
+      // Act.
+      sut.LogFieldPresent(_lineNumber, _fieldSpecification, rawData.AsSpan());
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   #endregion
+
+   #region LogFieldPresentButNull Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_LogFieldPresentButNull_ShouldAddExpectedEntry()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = String.Format(Messages.LogFieldPresentButNull, _fieldSpecification.FieldDescription);
+      var rawData = "\"\"";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         rawData);
+
+      // Act.
+      sut.LogFieldPresentButNull(_lineNumber, _fieldSpecification);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   #endregion
+
+   #region LogInformation Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_LogInformation_ShouldAddExpectedEntry_WhenOnlyRequiredParametersAreIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+
+      var expectedEntry = new LogEntry(LogLevel.Information, message, _lineNumber);
+
+      // Act.
+      sut.LogInformation(message, _lineNumber);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogInformation_ShouldAddExpectedEntry_WhenFieldSpecificationIsIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription);
+
+      // Act.
+      sut.LogInformation(message, _lineNumber, _fieldSpecification);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogInformation_ShouldAddExpectedEntry_WhenRawDataIsIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         RawData: rawData);
+
+      // Act.
+      sut.LogInformation(message, _lineNumber, rawData: rawData);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogInformation_ShouldAddExpectedEntry_WhenAllParametersAreIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         rawData);
+
+      // Act.
+      sut.LogInformation(message, _lineNumber, _fieldSpecification, rawData);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   #endregion
+
+   #region LogWarning Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_LogWarning_ShouldAddExpectedEntry_WhenOnlyRequiredParametersAreIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+
+      var expectedEntry = new LogEntry(LogLevel.Warning, message, _lineNumber);
+
+      // Act.
+      sut.LogWarning(message, _lineNumber);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogWarning_ShouldAddExpectedEntry_WhenFieldSpecificationIsIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Warning,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription);
+
+      // Act.
+      sut.LogWarning(message, _lineNumber, _fieldSpecification);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogWarning_ShouldAddExpectedEntry_WhenRawDataIsIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Warning,
+         message,
+         _lineNumber,
+         RawData: rawData);
+
+      // Act.
+      sut.LogWarning(message, _lineNumber, rawData: rawData);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogWarning_ShouldAddExpectedEntry_WhenAllParametersAreIncluded()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+
+      var message = "My message";
+      var rawData = "this is a test...this is only a test...";
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Warning,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         rawData);
+
+      // Act.
+      sut.LogWarning(message, _lineNumber, _fieldSpecification, rawData);
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   #endregion
+}

--- a/Tests/HL7.Net.Tests.Unit/Core/SpanExtensionsTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/SpanExtensionsTests.cs
@@ -11,10 +11,11 @@ public class SpanExtensionsTests
    {
       // Arrange.
       var span = "This is a test|This is only a test|For the next sixty seconds...".AsSpan();
-      var fieldSeparator = '|';
+      var fieldSeparator = DefaultSeparators.FieldSeparator;
+      var escapeCharacter = DefaultSeparators.EscapeCharacter;
 
       // Act.
-      var result = span.ToFields(fieldSeparator);
+      var result = span.ToFields(fieldSeparator, escapeCharacter);
 
       // Assert.
       result.Current.ToString().Should().BeEmpty();
@@ -143,11 +144,64 @@ public class SpanExtensionsTests
       var text = @"This is a test\This is only a test";
       var span = text.AsSpan();
 
+      var expected = @"This is a testThis is only a test";
+
       // Act.
       var decoded = span.GetDecodedString(encodingDetails);
 
       // Assert.
-      decoded.Should().Be(text);
+      decoded.Should().Be(expected);
+   }
+
+   [Fact]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanContainsLeadingEscapeSequence()
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var text = @"\This is a test";
+      var span = text.AsSpan();
+
+      var expected = @"This is a test";
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().Be(expected);
+   }
+
+   [Fact]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanContainsTrailingEscapeCharacter()
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var text = @"This is a test\";
+      var span = text.AsSpan();
+
+      var expected = @"This is a test";
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().Be(expected);
+   }
+
+   [Fact]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanContainsOnlyASingleEscapeCharacter()
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var text = @"\";
+      var span = text.AsSpan();
+
+      var expected = String.Empty;
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().Be(expected);
    }
 
    #endregion

--- a/Tests/HL7.Net.Tests.Unit/Core/SpanExtensionsTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/SpanExtensionsTests.cs
@@ -1,0 +1,154 @@
+﻿namespace HL7.Net.Tests.Unit.Core;
+
+public class SpanExtensionsTests
+{
+   #region ToFields Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void SpanExtensions_ToFields_ShouldReturnFieldEnumerator()
+   {
+      // Arrange.
+      var span = "This is a test|This is only a test|For the next sixty seconds...".AsSpan();
+      var fieldSeparator = '|';
+
+      // Act.
+      var result = span.ToFields(fieldSeparator);
+
+      // Assert.
+      result.Current.ToString().Should().BeEmpty();
+   }
+
+   #endregion
+
+   #region ToLines Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void SpanExtensions_ToLines_ShouldReturnLineEnumerator()
+   {
+      // Arrange.
+      var span = "This is a test\r\nThis is only a test\r\nFor the next sixty seconds...".AsSpan();
+
+      // Act.
+      var result = span.ToLines();
+
+      // Assert.
+      result.Current.ToString().Should().BeEmpty();
+   }
+
+   #endregion
+
+   #region GetDecodedString Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanContainsNoEscapedSequences()
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var text = "abc...QWERTY";
+      var span = text.AsSpan();
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().Be(text);
+   }
+
+   [Theory]
+   [InlineData(DefaultSeparators.FieldSeparator)]
+   [InlineData(DefaultSeparators.ComponentSeparator)]
+   [InlineData(DefaultSeparators.RepetitionSeparator)]
+   [InlineData(DefaultSeparators.EscapeCharacter)]
+   [InlineData(DefaultSeparators.SubComponentSeparator)]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanContainsSingleEscapeSequence(Char escapedCharacter)
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var text = $"abc{encodingDetails.EscapeCharacter}{escapedCharacter}QWERTY";
+      var span = text.AsSpan();
+
+      var expected = $"abc{escapedCharacter}QWERTY";
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().Be(expected);
+   }
+
+   [Theory]
+   [InlineData(DefaultSeparators.FieldSeparator)]
+   [InlineData(DefaultSeparators.ComponentSeparator)]
+   [InlineData(DefaultSeparators.RepetitionSeparator)]
+   [InlineData(DefaultSeparators.EscapeCharacter)]
+   [InlineData(DefaultSeparators.SubComponentSeparator)]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanContainsMultipleEscapeSequences(Char escapedCharacter)
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var text = $"abc{encodingDetails.EscapeCharacter}{escapedCharacter}QWERTY{encodingDetails.EscapeCharacter}{escapedCharacter}123{encodingDetails.EscapeCharacter}{escapedCharacter}xyz";
+      var span = text.AsSpan();
+
+      var expected = $"abc{escapedCharacter}QWERTY{escapedCharacter}123{escapedCharacter}xyz";
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().Be(expected);
+   }
+
+   [Fact]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanContainsDifferentEscapeSequences()
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var text = $"abc{encodingDetails.EscapeCharacter}{encodingDetails.SubComponentSeparator}QWERTY{encodingDetails.EscapeCharacter}{encodingDetails.EscapeCharacter}123{encodingDetails.EscapeCharacter}{encodingDetails.RepetitionSeparator}xyz{encodingDetails.EscapeCharacter}{encodingDetails.ComponentSeparator}asdf";
+      var span = text.AsSpan();
+
+      var expected = $"abc{encodingDetails.SubComponentSeparator}QWERTY{encodingDetails.EscapeCharacter}123{encodingDetails.RepetitionSeparator}xyz{encodingDetails.ComponentSeparator}asdf";
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().Be(expected);
+   }
+
+   [Fact]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanIsEmpty()
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var span = String.Empty.AsSpan();
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().BeEmpty();
+   }
+
+   [Fact]
+   public void SpanExtensions_GetDecodedString_ShouldReturnExpectedResult_WhenSpanContainsInvalidEscapeSequence()
+   {
+      // Arrange.
+      var encodingDetails = EncodingDetails.DefaultEncodingDetails;
+      var text = @"This is a test\This is only a test";
+      var span = text.AsSpan();
+
+      // Act.
+      var decoded = span.GetDecodedString(encodingDetails);
+
+      // Assert.
+      decoded.Should().Be(text);
+   }
+
+   #endregion
+}

--- a/Tests/HL7.Net.Tests.Unit/Core/StringFieldTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/StringFieldTests.cs
@@ -1,0 +1,131 @@
+﻿namespace HL7.Net.Tests.Unit.Core;
+
+public class StringFieldTests
+{
+   private static readonly EncodingDetails _encodingDetails = new(
+      DefaultSeparators.FieldSeparator,
+      DefaultSeparators.ComponentSeparator,
+      DefaultSeparators.RepetitionSeparator,
+      DefaultSeparators.EscapeCharacter,
+      DefaultSeparators.SubComponentSeparator);
+   private static readonly FieldSpecification _fieldSpecification = new(
+      "TST",
+      1,
+      "Test Field",
+      15,
+      HL7Datatype.ST_String,
+      Optionality.Optional,
+      "N");
+   private const Int32 _lineNumber = 10;
+
+   #region Internal Constructor Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void StringField_Constructor_ShouldReturnNotPresentInstance_WhenFieldIsEmpty()
+   {
+      // Arrange.
+      var line = "TST||This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      // Act.
+      var field = StringField.Parse(
+         ref fieldEnumerator, 
+         _encodingDetails, 
+         _fieldSpecification, 
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(StringField.NotPresent);
+   }
+
+   [Fact]
+   public void StringField_Constructor_ShouldLogNotPresentField_WhenFieldIsEmpty()
+   {
+      // Arrange.
+      var line = "TST||This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var expectedLogMessage = String.Format(
+         Messages.LogFieldNotPresent,
+         _fieldSpecification.FieldDescription);
+
+      // Act.
+      var field = StringField.Parse(
+         ref fieldEnumerator,
+         _encodingDetails,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      var entry = log.First();
+      entry.LogLevel.Should().Be(LogLevel.Information);
+      entry.Message.Should().Be(expectedLogMessage);
+      entry.FieldDescription.Should().Be(_fieldSpecification.FieldDescription);
+      entry.LineNumber.Should().Be(_lineNumber);
+      entry.RawData.Should().BeNull();
+   }
+
+   [Fact]
+   public void StringField_Constructor_ShouldReturnPresentButNullInstance_WhenFieldIsTwoDoubleQuotes()
+   {
+      // Arrange.
+      var line = "TST|\"\"|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      // Act.
+      var field = StringField.Parse(
+         ref fieldEnumerator,
+         _encodingDetails,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(StringField.PresentButNull);
+   }
+
+   [Fact]
+   public void StringField_Constructor_ShouldLogPresentButNullField_WhenFieldIsTwoDoubleQuotes()
+   {
+      // Arrange.
+      var line = "TST|\"\"|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var expectedLogMessage = String.Format(
+         Messages.LogFieldPresentButNull,
+         _fieldSpecification.FieldDescription);
+      var expectedRawData = "\"\"";
+
+      // Act.
+      var field = StringField.Parse(
+         ref fieldEnumerator,
+         _encodingDetails,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      var entry = log.First();
+      entry.LogLevel.Should().Be(LogLevel.Information);
+      entry.Message.Should().Be(expectedLogMessage);
+      entry.FieldDescription.Should().Be(_fieldSpecification.FieldDescription);
+      entry.LineNumber.Should().Be(_lineNumber);
+      entry.RawData.Should().Be(expectedRawData);
+   }
+
+   #endregion
+}

--- a/Tests/HL7.Net.Tests.Unit/Core/StringFieldTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/StringFieldTests.cs
@@ -2,12 +2,7 @@
 
 public class StringFieldTests
 {
-   private static readonly EncodingDetails _encodingDetails = new(
-      DefaultSeparators.FieldSeparator,
-      DefaultSeparators.ComponentSeparator,
-      DefaultSeparators.RepetitionSeparator,
-      DefaultSeparators.EscapeCharacter,
-      DefaultSeparators.SubComponentSeparator);
+   private static readonly EncodingDetails _encodingDetails = EncodingDetails.DefaultEncodingDetails;
    private static readonly FieldSpecification _fieldSpecification = new(
       "TST",
       1,
@@ -277,11 +272,11 @@ public class StringFieldTests
    }
 
    [Theory]
-   [InlineData('^')]
-   [InlineData('~')]
-   [InlineData('\\')]
-   [InlineData('&')]
-   [InlineData('|')]
+   [InlineData(DefaultSeparators.FieldSeparator)]
+   [InlineData(DefaultSeparators.ComponentSeparator)]
+   [InlineData(DefaultSeparators.RepetitionSeparator)]
+   [InlineData(DefaultSeparators.EscapeCharacter)]
+   [InlineData(DefaultSeparators.SubComponentSeparator)]
    public void StringField_Constructor_ShouldReturnExpectedField_WhenRawDataContainsEscapedCharacters(Char escapedChar)
    {
       // Arrange.
@@ -307,11 +302,11 @@ public class StringFieldTests
    }
 
    [Theory]
-   [InlineData('^')]
-   [InlineData('~')]
-   [InlineData('\\')]
-   [InlineData('&')]
-   [InlineData('|')]
+   [InlineData(DefaultSeparators.FieldSeparator)]
+   [InlineData(DefaultSeparators.ComponentSeparator)]
+   [InlineData(DefaultSeparators.RepetitionSeparator)]
+   [InlineData(DefaultSeparators.EscapeCharacter)]
+   [InlineData(DefaultSeparators.SubComponentSeparator)]
    public void StringField_Constructor_ShouldLogExpectedEntry_WhenRawDataContainsEscapedCharacters(Char escapedChar)
    {
       // Arrange.
@@ -343,11 +338,11 @@ public class StringFieldTests
    }
 
    [Theory]
-   [InlineData('^')]
-   [InlineData('~')]
-   [InlineData('\\')]
-   [InlineData('&')]
-   [InlineData('|')]
+   [InlineData(DefaultSeparators.FieldSeparator)]
+   [InlineData(DefaultSeparators.ComponentSeparator)]
+   [InlineData(DefaultSeparators.RepetitionSeparator)]
+   [InlineData(DefaultSeparators.EscapeCharacter)]
+   [InlineData(DefaultSeparators.SubComponentSeparator)]
    public void StringField_Constructor_ShouldReturnExpectedField_WhenRawDataContainsEscapedCharactersAndDecodedValueExceedsFieldMaxLength(Char escapedChar)
    {
       // Arrange.
@@ -374,11 +369,11 @@ public class StringFieldTests
    }
 
    [Theory]
-   [InlineData('^')]
-   [InlineData('~')]
-   [InlineData('\\')]
-   [InlineData('&')]
-   [InlineData('|')]
+   [InlineData(DefaultSeparators.FieldSeparator)]
+   [InlineData(DefaultSeparators.ComponentSeparator)]
+   [InlineData(DefaultSeparators.RepetitionSeparator)]
+   [InlineData(DefaultSeparators.EscapeCharacter)]
+   [InlineData(DefaultSeparators.SubComponentSeparator)]
    public void StringField_Constructor_ShouldLogExpectedEntry_WhenRawDataContainsEscapedCharactersAndDecodedValueExceedsFieldMaxLength(Char escapedChar)
    {
       // Arrange.


### PR DESCRIPTION
# S0003-StringDatatype

As a developer who uses HL7.Net, I want the HL7 ST datatype to be fully supported
when parsing messages.

## Requirements

- StringField class that implements TX datatype as per HL7 V2.2 spec section 2.8.10.1
- Support field max length
- Support escaped characters

## Definition of DONE

1. StringField class
2. Unit tests for StringField method