### PR TITLE
NumericField and SequenceIDField with associated unit tests

### DIFF
--- a/Source/HL7.Net/Core/GeneralConstants.cs
+++ b/Source/HL7.Net/Core/GeneralConstants.cs
@@ -1,6 +1,12 @@
-﻿namespace HL7.Net.Core;
+﻿
+namespace HL7.Net.Core;
 
 internal static class GeneralConstants
 {
    public const String PresentButNullValue = "\"\"";
+
+   public const NumberStyles NumericValueStyle = 
+      NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint;
+
+   public const NumberStyles SequenceIdStyle = NumberStyles.None;
 }

--- a/Source/HL7.Net/Core/NumericField.cs
+++ b/Source/HL7.Net/Core/NumericField.cs
@@ -1,0 +1,75 @@
+﻿namespace HL7.Net.Core;
+
+/// <summary>
+///   A field containing numeric data. Implements HL7 V2.2 spec section 2.8.10.4.
+/// </summary>
+public sealed record NumericField
+{
+   /// <summary>
+   ///   Represents an numeric field that is not present.
+   /// </summary>
+   public static readonly NumericField NotPresent = new(null, FieldPresence.NotPresent);
+
+   /// <summary>
+   ///   Represents a numeric field that is present but is null.
+   /// </summary>
+   public static readonly NumericField PresentButNull = new(null, FieldPresence.PresentButNull);
+
+   internal NumericField(
+      Decimal? value,
+      FieldPresence fieldPresence = FieldPresence.Present)
+   {
+      Value = value;
+      FieldPresence = fieldPresence;
+   }
+
+   public static implicit operator Decimal?(NumericField field) => field.Value;
+
+   /// <summary>
+   ///   Identifies if this field is present in the message and if the value of
+   ///   the field is null or not.
+   /// </summary>
+   public FieldPresence FieldPresence { get; init; }
+
+   /// <summary>
+   ///   The value of this field.
+   /// </summary>
+   public Decimal? Value { get; init; }
+
+   internal static NumericField Parse(
+      ref FieldEnumerator fieldEnumerator,
+      FieldSpecification fieldSpecification,
+      Int32 lineNumber,
+      ProcessingLog log)
+   {
+      if (!fieldEnumerator.MoveNext() || fieldEnumerator.Current.IsEmpty)
+      {
+         log.LogFieldNotPresent(lineNumber, fieldSpecification);
+         return NumericField.NotPresent;
+      }
+
+      if (fieldEnumerator.Current.IsPresentButNull())
+      {
+         log.LogFieldPresentButNull(lineNumber, fieldSpecification);
+         return NumericField.PresentButNull;
+      }
+
+      var fieldContents = fieldEnumerator.Current.Length > fieldSpecification.Length
+         ? fieldEnumerator.Current[..fieldSpecification.Length]
+         : fieldEnumerator.Current;
+      if (Decimal.TryParse(fieldContents, GeneralConstants.NumericValueStyle, null, out var value))
+      {
+         log.LogFieldPresentButPossiblyTruncated(
+            lineNumber, 
+            fieldSpecification, 
+            fieldEnumerator.Current);
+         return new NumericField(value);
+      }
+
+      var message = String.Format(
+         Messages.InvalidNumericValue,
+         fieldSpecification.FieldDescription);
+      log.LogError(message, lineNumber, fieldSpecification, fieldEnumerator.Current.ToString());
+      return NumericField.NotPresent;
+   }
+}

--- a/Source/HL7.Net/Core/ProcessingLog.cs
+++ b/Source/HL7.Net/Core/ProcessingLog.cs
@@ -82,6 +82,29 @@ public class ProcessingLog : IEnumerable<LogEntry>
       LogInformation(message, lineNumber, fieldSpecification, "\"\"");
    }
 
+   internal void LogFieldPresentButPossiblyTruncated(
+      Int32 lineNumber,
+      FieldSpecification fieldSpecification,
+      ReadOnlySpan<Char> fieldContents)
+   {
+      String message;
+      if (fieldContents.Length > fieldSpecification.Length)
+      {
+         message = String.Format(
+            Messages.LogFieldPresentButTruncated,
+            fieldSpecification.FieldDescription,
+            fieldSpecification.Length);
+         LogWarning(message, lineNumber, fieldSpecification, fieldContents.ToString());
+      }
+      else
+      {
+         message = String.Format(
+            Messages.LogFieldPresent,
+            fieldSpecification.FieldDescription);
+         LogInformation(message, lineNumber, fieldSpecification, fieldContents.ToString());
+      }
+   }
+
    internal void LogInformation(
       String message,
       Int32 lineNumber,

--- a/Source/HL7.Net/Core/SequenceIDField.cs
+++ b/Source/HL7.Net/Core/SequenceIDField.cs
@@ -1,0 +1,76 @@
+﻿namespace HL7.Net.Core;
+
+/// <summary>
+///   A field containing an integer sequence id. Implements HL7 V2.2 spec 
+///   section 2.8.10.12.
+/// </summary>
+public sealed record SequenceIDField
+{
+   /// <summary>
+   ///   Represents an sequence id field that is not present.
+   /// </summary>
+   public static readonly SequenceIDField NotPresent = new(null, FieldPresence.NotPresent);
+
+   /// <summary>
+   ///   Represents a sequence id field that is present but is null.
+   /// </summary>
+   public static readonly SequenceIDField PresentButNull = new(null, FieldPresence.PresentButNull);
+
+   internal SequenceIDField(
+      Int32? value,
+      FieldPresence fieldPresence = FieldPresence.Present)
+   {
+      Value = value;
+      FieldPresence = fieldPresence;
+   }
+
+   public static implicit operator Int32?(SequenceIDField field) => field.Value;
+
+   /// <summary>
+   ///   Identifies if this field is present in the message and if the value of
+   ///   the field is null or not.
+   /// </summary>
+   public FieldPresence FieldPresence { get; init; }
+
+   /// <summary>
+   ///   The value of this field.
+   /// </summary>
+   public Int32? Value { get; init; }
+
+   internal static SequenceIDField Parse(
+      ref FieldEnumerator fieldEnumerator,
+      FieldSpecification fieldSpecification,
+      Int32 lineNumber,
+      ProcessingLog log)
+   {
+      if (!fieldEnumerator.MoveNext() || fieldEnumerator.Current.IsEmpty)
+      {
+         log.LogFieldNotPresent(lineNumber, fieldSpecification);
+         return SequenceIDField.NotPresent;
+      }
+
+      if (fieldEnumerator.Current.IsPresentButNull())
+      {
+         log.LogFieldPresentButNull(lineNumber, fieldSpecification);
+         return SequenceIDField.PresentButNull;
+      }
+
+      var fieldContents = fieldEnumerator.Current.Length > fieldSpecification.Length
+         ? fieldEnumerator.Current[..fieldSpecification.Length]
+         : fieldEnumerator.Current;
+      if (Int32.TryParse(fieldContents, GeneralConstants.SequenceIdStyle, null, out var value))
+      {
+         log.LogFieldPresentButPossiblyTruncated(
+            lineNumber,
+            fieldSpecification,
+            fieldEnumerator.Current);
+         return new SequenceIDField(value);
+      }
+
+      var message = String.Format(
+         Messages.InvalidNumericValue,
+         fieldSpecification.FieldDescription);
+      log.LogError(message, lineNumber, fieldSpecification, fieldEnumerator.Current.ToString());
+      return SequenceIDField.NotPresent;
+   }
+}

--- a/Source/HL7.Net/Core/SpanExtensions.cs
+++ b/Source/HL7.Net/Core/SpanExtensions.cs
@@ -92,4 +92,18 @@ public static class SpanExtensions
 
       return startIndex + indexInSlice;
    }
+
+   /// <summary>
+   ///   Check if the span contains the HL7 representation of a value that is 
+   ///   present, but null.
+   /// </summary>
+   /// <param name="span">
+   ///   The span to check.
+   /// </param>
+   /// <returns>
+   ///   <see langword="true"/> if the span contains the HL7 representation of a 
+   ///   value that is present, but null; otherwise <see langword="false"/>.
+   /// </returns>
+   public static Boolean IsPresentButNull(this ReadOnlySpan<char> span)
+      => span.Length == 2 && span[0] == '"' && span[1] == '"';
 }

--- a/Source/HL7.Net/GlobalUsings.cs
+++ b/Source/HL7.Net/GlobalUsings.cs
@@ -1,4 +1,5 @@
 ﻿global using System.Collections;
+global using System.Globalization;
 global using System.Runtime.CompilerServices;
 
 global using HL7.Net.Core;

--- a/Source/HL7.Net/Messages.Designer.cs
+++ b/Source/HL7.Net/Messages.Designer.cs
@@ -70,6 +70,15 @@ namespace HL7.Net {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Field {0} contains data that could not be parsed as an integer value.
+        /// </summary>
+        internal static string InvalidIntegerNumericValue {
+            get {
+                return ResourceManager.GetString("InvalidIntegerNumericValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value must be an integer greater than zero (0) or minus one (-1) to indicate that the field allows unlimited length.
         /// </summary>
         internal static string InvalidMaxLength {
@@ -84,6 +93,15 @@ namespace HL7.Net {
         internal static string InvalidNumberOfRepetitionsAllowed {
             get {
                 return ResourceManager.GetString("InvalidNumberOfRepetitionsAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Field {0} contains data that could not be parsed as an numeric value.
+        /// </summary>
+        internal static string InvalidNumericValue {
+            get {
+                return ResourceManager.GetString("InvalidNumericValue", resourceCulture);
             }
         }
         

--- a/Source/HL7.Net/Messages.resx
+++ b/Source/HL7.Net/Messages.resx
@@ -120,11 +120,17 @@
   <data name="InvalidFieldSeparator" xml:space="preserve">
     <value>Field separator character may not be carriage return (hex 0D)</value>
   </data>
+  <data name="InvalidIntegerNumericValue" xml:space="preserve">
+    <value>Field {0} contains data that could not be parsed as an integer value</value>
+  </data>
   <data name="InvalidMaxLength" xml:space="preserve">
     <value>Value must be an integer greater than zero (0) or minus one (-1) to indicate that the field allows unlimited length</value>
   </data>
   <data name="InvalidNumberOfRepetitionsAllowed" xml:space="preserve">
     <value>Allowed repetitions must be greater than one (1)</value>
+  </data>
+  <data name="InvalidNumericValue" xml:space="preserve">
+    <value>Field {0} contains data that could not be parsed as an numeric value</value>
   </data>
   <data name="InvalidRepetitionSpecification" xml:space="preserve">
     <value>Value is not 'N', 'Y' or a integer greater than one (1)</value>

--- a/Source/HL7.Net/V2Point2/PatientIdentificationSegment.cs
+++ b/Source/HL7.Net/V2Point2/PatientIdentificationSegment.cs
@@ -48,7 +48,7 @@ public class PatientIdentificationSegment : ISegment
    ///   For those messages that permit segments to repeat, the Set ID field is 
    ///   used to identify the repetitions.
    /// </summary>
-   public StringField SetID { get; private set; } = default!;
+   public SequenceIDField SetID { get; private set; } = default!;
 
    /// <summary>
    ///   If the patient is from another institution, outside office, etc., the 
@@ -174,7 +174,7 @@ public class PatientIdentificationSegment : ISegment
    ///   If a patient was part of a multiple birth, a value (number) indicating 
    ///   the patient's birth order.
    /// </summary>
-   public StringField BirthOrder { get; private set; } = default!;
+   public NumericField BirthOrder { get; private set; } = default!;
 
    /// <summary>
    ///   Indicates the patient's country of citizenship.
@@ -201,9 +201,8 @@ public class PatientIdentificationSegment : ISegment
          encodingDetails.EscapeCharacter);
       fieldEnumerator.MoveNext();
 
-      segment.SetID = StringField.Parse(
+      segment.SetID = SequenceIDField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[0],
          lineNumber,
          log);
@@ -369,9 +368,8 @@ public class PatientIdentificationSegment : ISegment
          lineNumber,
          log);
 
-      segment.BirthOrder = StringField.Parse(
+      segment.BirthOrder = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[24],
          lineNumber,
          log);

--- a/Source/HL7.Net/V2Point2/PatientVisitSegment.cs
+++ b/Source/HL7.Net/V2Point2/PatientVisitSegment.cs
@@ -74,7 +74,7 @@ public class PatientVisitSegment : ISegment
    ///   permit segments to repeat, the Set ID field is used to identify the
    ///   repetitions.
    /// </summary>
-   public StringField SetID { get; private set; } = default!;
+   public SequenceIDField SetID { get; private set; } = default!;
 
    /// <summary>
    ///   A common field used by systems to categorize patients by site.
@@ -209,12 +209,12 @@ public class PatientVisitSegment : ISegment
    /// <summary>
    ///   Amount to be paid by the guarantor each period as per the contract.
    /// </summary>
-   public StringField ContractAmount { get; private set; } = default!;
+   public NumericField ContractAmount { get; private set; } = default!;
 
    /// <summary>
    ///   Specifies the duration of the contract for user-defined periods.
    /// </summary>
-   public StringField ContractPeriod { get; private set; } = default!;
+   public NumericField ContractPeriod { get; private set; } = default!;
 
    /// <summary>
    ///   Indicates the amount of interest that will be charged the guarantor on 
@@ -241,12 +241,12 @@ public class PatientVisitSegment : ISegment
    /// <summary>
    ///   Amount that was transferred to a bad debt status.
    /// </summary>
-   public StringField BadDebtTransferAmount { get; private set; } = default!;
+   public NumericField BadDebtTransferAmount { get; private set; } = default!;
 
    /// <summary>
    ///   Amount recovered from the guarantor on the account.
    /// </summary>
-   public StringField BadDebtRecoveryAmount { get; private set; } = default!;
+   public NumericField BadDebtRecoveryAmount { get; private set; } = default!;
 
    /// <summary>
    ///   Indicates that the account was deleted from the file and the reason.
@@ -317,22 +317,22 @@ public class PatientVisitSegment : ISegment
    /// <summary>
    ///   Visit balance due. 
    /// </summary>
-   public StringField CurrentPatientBalance { get; private set; } = default!;
+   public NumericField CurrentPatientBalance { get; private set; } = default!;
 
    /// <summary>
    ///   Total visit charges.
    /// </summary>
-   public StringField TotalCharges { get; private set; } = default!;
+   public NumericField TotalCharges { get; private set; } = default!;
 
    /// <summary>
    ///   Total adjustments for visit.
    /// </summary>
-   public StringField TotalAdjustments { get; private set; } = default!;
+   public NumericField TotalAdjustments { get; private set; } = default!;
 
    /// <summary>
    ///   Total payments for visit.
    /// </summary>
-   public StringField TotalPayments { get; private set; } = default!;
+   public NumericField TotalPayments { get; private set; } = default!;
 
    /// <summary>
    ///   Optional visit ID number to be used if needed
@@ -354,9 +354,8 @@ public class PatientVisitSegment : ISegment
          encodingDetails.EscapeCharacter);
       fieldEnumerator.MoveNext();
 
-      segment.SetID = StringField.Parse(
+      segment.SetID = SequenceIDField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[0],
          lineNumber,
          log);
@@ -529,16 +528,14 @@ public class PatientVisitSegment : ISegment
          lineNumber,
          log);
 
-      segment.ContractAmount = StringField.Parse(
+      segment.ContractAmount = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[25],
          lineNumber,
          log);
 
-      segment.ContractPeriod = StringField.Parse(
+      segment.ContractPeriod = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[26],
          lineNumber,
          log);
@@ -571,16 +568,14 @@ public class PatientVisitSegment : ISegment
          lineNumber,
          log);
 
-      segment.BadDebtTransferAmount = StringField.Parse(
+      segment.BadDebtTransferAmount = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[31],
          lineNumber,
          log);
 
-      segment.BadDebtRecoveryAmount = StringField.Parse(
+      segment.BadDebtRecoveryAmount = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[32],
          lineNumber,
          log);
@@ -669,30 +664,26 @@ public class PatientVisitSegment : ISegment
          lineNumber,
          log);
 
-      segment.CurrentPatientBalance = StringField.Parse(
+      segment.CurrentPatientBalance = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[45],
          lineNumber,
          log);
 
-      segment.TotalCharges = StringField.Parse(
+      segment.TotalCharges = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[46],
          lineNumber,
          log);
 
-      segment.TotalAdjustments = StringField.Parse(
+      segment.TotalAdjustments = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[47],
          lineNumber,
          log);
 
-      segment.TotalPayments = StringField.Parse(
+      segment.TotalPayments = NumericField.Parse(
          ref fieldEnumerator,
-         encodingDetails,
          _fieldSpecifications[48],
          lineNumber,
          log);

--- a/Tests/HL7.Net.Tests.Unit/Core/NumericFieldTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/NumericFieldTests.cs
@@ -1,0 +1,537 @@
+﻿namespace HL7.Net.Tests.Unit.Core;
+
+public class NumericFieldTests
+{
+   private static readonly EncodingDetails _encodingDetails = EncodingDetails.DefaultEncodingDetails;
+   private static readonly FieldSpecification _fieldSpecification = new(
+      "TST",
+      1,
+      "Test Field",
+      8,
+      HL7Datatype.NM_Numeric,
+      Optionality.Optional,
+      "N");
+   private const Int32 _lineNumber = 10;
+
+   #region Internal Constructor Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NumericField_Constructor_ShouldCreateObject_WhenValueIsSupplied()
+   {
+      var value = 42.42M;
+
+      // Act.
+      var sut = new NumericField(value);
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().Be(value);
+      sut.FieldPresence.Should().Be(FieldPresence.Present);
+   }
+
+   [Fact]
+   public void NumericField_Constructor_ShouldCreateObject_WhenValueAndFieldPresenceAreSupplied()
+   {
+      var value = 42.42M;
+
+      // Act.
+      var sut = new NumericField(value, FieldPresence.NotPresent);
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().Be(value);
+      sut.FieldPresence.Should().Be(FieldPresence.NotPresent);
+   }
+
+   #endregion
+
+   #region Implicit Decimal Converter Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NumericField_ImplicitDecimalConverter_ShouldReturnExpectedValue_WhenFieldIsNotEmpty()
+   {
+      // Arrange.
+      var value = 42.42M;
+      var sut = new NumericField(value);
+
+      // Act.
+      Decimal? result = sut;
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void NumericField_ImplicitDecimalConverter_ShouldReturnExpectedValue_WhenFieldIsNotPresent()
+   {
+      // Arrange.
+      var sut = NumericField.NotPresent;
+
+      // Act.
+      Decimal? result = sut;
+
+      // Assert.
+      result.Should().BeNull();
+   }
+
+   #endregion
+
+   #region NotPresent Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NumericField_NotPresent_ShouldReturnExpectedValue()
+   {
+      // Act.
+      var sut = NumericField.NotPresent;
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().BeNull();
+      sut.FieldPresence.Should().Be(FieldPresence.NotPresent);
+   }
+
+   #endregion
+
+   #region PresentButNull Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void NumericField_PresentButNull_ShouldReturnExpectedValue()
+   {
+      // Act.
+      var sut = NumericField.PresentButNull;
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().BeNull();
+      sut.FieldPresence.Should().Be(FieldPresence.PresentButNull);
+   }
+
+   #endregion
+
+   #region Parse Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData("42", 42)]
+   [InlineData("+42", 42)]
+   [InlineData("-42", -42)]
+   [InlineData("42.42", 42.42)]
+   [InlineData("12345678 ", 12345678)]
+   [InlineData("1234.567", 1234.567)]
+   [InlineData("-1234.56", -1234.56)]
+   public void NumericField_Parse_ShouldReturnIntegerValue_WhenFieldContainsValidNumericValue(
+      String fieldContents,
+      Decimal expectedValue)
+   {
+      // Arrange.
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var expected = new NumericField(expectedValue);
+
+      // Act.
+      var field = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(expected);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldLogExpectedEntry_WhenFieldContainsValidNumericValue()
+   {
+      // Arrange.
+      var fieldContents = "42.42";
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(Messages.LogFieldPresent, _fieldSpecification.FieldDescription);
+
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         fieldContents);
+
+      // Act.
+      _ = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Theory]
+   [InlineData("$42")]
+   [InlineData("42GBP")]
+   [InlineData("42-")]
+   [InlineData("(42)")]
+   [InlineData(" 42")]
+   [InlineData("42 ")]
+   [InlineData(" 42 ")]
+   [InlineData("   ")]
+   [InlineData("42,000")]
+   [InlineData("42E-3")]
+   public void NumericField_Parse_ShouldReturnNotPresentInstance_WhenFieldContainsAnInvalidNumericValue(String fieldContents)
+   {
+      // Arrange.
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      // Act.
+      var field = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(NumericField.NotPresent);
+   }
+
+   [Theory]
+   [InlineData("$42")]
+   [InlineData("42GBP")]
+   [InlineData("42-")]
+   [InlineData("(42)")]
+   [InlineData(" 42")]
+   [InlineData("42 ")]
+   [InlineData(" 42 ")]
+   [InlineData("   ")]
+   [InlineData("42,000")]
+   [InlineData("42E-3")]
+   public void NumericField_Parse_ShouldLogError_WhenFieldContainsAnInvalidNumericValue(String fieldContents)
+   {
+      // Arrange.
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(
+         Messages.InvalidNumericValue,
+         _fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         fieldContents);
+
+      // Act.
+      _ = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldTruncateValue_WhenFieldIsLongerThanMaxLength()
+   {
+      // Arrange.
+      var fieldContents = "1234.0012345";
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var expectedValue = 1234.001M;
+      var expected = new NumericField(expectedValue);
+
+      // Act.
+      var field = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(expected);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldLogExpectedEntry_WhenFieldIsLongerThanMaxLength()
+   {
+      // Arrange.
+      var fieldContents = "1234.0012345";
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(
+         Messages.LogFieldPresentButTruncated,
+         _fieldSpecification.FieldDescription,
+         _fieldSpecification.Length);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Warning,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         fieldContents);
+
+      // Act.
+      _ = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Theory]
+   [InlineData(Optionality.Optional)]
+   [InlineData(Optionality.Required)]
+   public void NumericField_Parse_ShouldReturnNotPresentInstance_WhenFieldIsBeyondEndOfSuppliedFields(Optionality optionality)
+   {
+      // Arrange.
+      var line = "TST|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+      var fieldSpecification = _fieldSpecification with { Optionality = optionality, Sequence = 2 };
+
+      // Act.
+      var field = NumericField.Parse(
+         ref fieldEnumerator,
+         fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(NumericField.NotPresent);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldLogFieldNotPresent_WhenOptionalFieldIsBeyondEndOfSuppliedFields()
+   {
+      // Arrange.
+      var line = "TST|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+      var fieldSpecification = _fieldSpecification with { Optionality = Optionality.Optional, Sequence = 2 };
+
+      var message = String.Format(
+         Messages.LogFieldNotPresent,
+         fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription);
+
+      // Act.
+      _ = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldLogRequiredFieldNotPresent_WhenRequiredFieldIsBeyondEndOfSuppliedFields()
+   {
+      // Arrange.
+      var line = "TST|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+      var fieldSpecification = _fieldSpecification with { Optionality = Optionality.Required, Sequence = 2 };
+
+      var message = String.Format(
+         Messages.LogRequiredFieldNotPresent,
+         fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription);
+
+      // Act.
+      _ = NumericField.Parse(
+         ref fieldEnumerator,
+         fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Theory]
+   [InlineData(Optionality.Optional)]
+   [InlineData(Optionality.Required)]
+   public void NumericField_Parse_ShouldReturnNotPresentInstance_WhenFieldIsEmpty(Optionality optionality)
+   {
+      // Arrange.
+      var line = "TST||This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+      var fieldSpecification = _fieldSpecification with { Optionality = optionality };
+
+      // Act.
+      var field = NumericField.Parse(
+         ref fieldEnumerator,
+         fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(NumericField.NotPresent);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldLogFieldNotPresent_WhenOptionalFieldIsEmpty()
+   {
+      // Arrange.
+      var line = "TST||This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(
+         Messages.LogFieldNotPresent,
+         _fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription);
+
+      // Act.
+      _ = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldLogRequiredFieldNotPresent_WhenRequiredFieldIsEmpty()
+   {
+      // Arrange.
+      var line = "TST||This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var fieldSpecification = _fieldSpecification with { Optionality = Optionality.Required };
+      var message = String.Format(
+         Messages.LogRequiredFieldNotPresent,
+         fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription);
+
+      // Act.
+      _ = NumericField.Parse(
+         ref fieldEnumerator,
+         fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldReturnPresentButNullInstance_WhenFieldIsTwoDoubleQuotes()
+   {
+      // Arrange.
+      var line = "TST|\"\"|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      // Act.
+      var field = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(NumericField.PresentButNull);
+   }
+
+   [Fact]
+   public void NumericField_Parse_ShouldLogFieldPresentButNull_WhenFieldIsTwoDoubleQuotes()
+   {
+      // Arrange.
+      var line = "TST|\"\"|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(
+         Messages.LogFieldPresentButNull,
+         _fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         GeneralConstants.PresentButNullValue);
+
+      // Act.
+      _ = NumericField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   #endregion
+}

--- a/Tests/HL7.Net.Tests.Unit/Core/ProcessingLogTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/ProcessingLogTests.cs
@@ -450,6 +450,63 @@ public class ProcessingLogTests
 
    #endregion
 
+   #region LogFieldPresentButPossiblyTruncated Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void ProcessingLog_LogFieldPresentButPossiblyTruncated_ShouldAddExpectedEntry_WhenFieldWasNotTruncated()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+      var fieldContents = "1234";
+      var fieldSpecification = _fieldSpecification with { Length = 5, Datatype = HL7Datatype.NM_Numeric };
+
+      var message = String.Format(Messages.LogFieldPresent, fieldSpecification.FieldDescription);
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription,
+         fieldContents);
+
+      // Act.
+      sut.LogFieldPresentButPossiblyTruncated(_lineNumber, fieldSpecification, fieldContents.AsSpan());
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   [Fact]
+   public void ProcessingLog_LogFieldPresentButPossiblyTruncated_ShouldAddExpectedEntry_WhenFieldWasTruncated()
+   {
+      // Arrange.
+      var sut = new ProcessingLog();
+      var fieldContents = "12345678";
+      var fieldSpecification = _fieldSpecification with { Length = 5, Datatype = HL7Datatype.NM_Numeric };
+
+      var message = String.Format(
+         Messages.LogFieldPresentButTruncated, 
+         fieldSpecification.FieldDescription,
+         fieldSpecification.Length);
+
+      var expectedEntry = new LogEntry(
+         LogLevel.Warning,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription,
+         fieldContents);
+
+      // Act.
+      sut.LogFieldPresentButPossiblyTruncated(_lineNumber, fieldSpecification, fieldContents.AsSpan());
+
+      // Assert.
+      sut.First().Should().Be(expectedEntry);
+   }
+
+   #endregion
+
    #region LogInformation Method Tests
    // ==========================================================================
    // ==========================================================================

--- a/Tests/HL7.Net.Tests.Unit/Core/SequenceIdFieldTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/SequenceIdFieldTests.cs
@@ -1,0 +1,542 @@
+﻿namespace HL7.Net.Tests.Unit.Core;
+
+public class SequenceIdFieldTests
+{
+   private static readonly EncodingDetails _encodingDetails = EncodingDetails.DefaultEncodingDetails;
+   private static readonly FieldSpecification _fieldSpecification = new(
+      "TST",
+      1,
+      "Test Field",
+      4,
+      HL7Datatype.SI_SequenceID,
+      Optionality.Optional,
+      "N");
+   private const Int32 _lineNumber = 10;
+
+   #region Internal Constructor Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void SequenceIDField_Constructor_ShouldCreateObject_WhenValueIsSupplied()
+   {
+      var value = 42;
+
+      // Act.
+      var sut = new SequenceIDField(value);
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().Be(value);
+      sut.FieldPresence.Should().Be(FieldPresence.Present);
+   }
+
+   [Fact]
+   public void SequenceIDField_Constructor_ShouldCreateObject_WhenValueAndFieldPresenceAreSupplied()
+   {
+      var value = 42;
+
+      // Act.
+      var sut = new SequenceIDField(value, FieldPresence.NotPresent);
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().Be(value);
+      sut.FieldPresence.Should().Be(FieldPresence.NotPresent);
+   }
+
+   #endregion
+
+   #region Implicit Integer Converter Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void SequenceIDField_ImplicitIntegerConverter_ShouldReturnExpectedValue_WhenFieldIsNotEmpty()
+   {
+      // Arrange.
+      var value = 42;
+      var sut = new SequenceIDField(value);
+
+      // Act.
+      Decimal? result = sut;
+
+      // Assert.
+      result.Should().Be(value);
+   }
+
+   [Fact]
+   public void SequenceIDField_ImplicitIntegerConverter_ShouldReturnExpectedValue_WhenFieldIsNotPresent()
+   {
+      // Arrange.
+      var sut = SequenceIDField.NotPresent;
+
+      // Act.
+      Decimal? result = sut;
+
+      // Assert.
+      result.Should().BeNull();
+   }
+
+   #endregion
+
+   #region NotPresent Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void SequenceIDField_NotPresent_ShouldReturnExpectedValue()
+   {
+      // Act.
+      var sut = SequenceIDField.NotPresent;
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().BeNull();
+      sut.FieldPresence.Should().Be(FieldPresence.NotPresent);
+   }
+
+   #endregion
+
+   #region PresentButNull Property Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void SequenceIDField_PresentButNull_ShouldReturnExpectedValue()
+   {
+      // Act.
+      var sut = SequenceIDField.PresentButNull;
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().BeNull();
+      sut.FieldPresence.Should().Be(FieldPresence.PresentButNull);
+   }
+
+   #endregion
+
+   #region Parse Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Theory]
+   [InlineData("42", 42)]
+   [InlineData("1234 ", 1234)]
+   public void SequenceIDField_Parse_ShouldReturnIntegerValue_WhenFieldContainsValidIntegerValue(
+      String fieldContents,
+      Int32 expectedValue)
+   {
+      // Arrange.
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var expected = new SequenceIDField(expectedValue);
+
+      // Act.
+      var field = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(expected);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldLogExpectedEntry_WhenFieldContainsValidIntegerValue()
+   {
+      // Arrange.
+      var fieldContents = "42";
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(Messages.LogFieldPresent, _fieldSpecification.FieldDescription);
+
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         fieldContents);
+
+      // Act.
+      _ = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Theory]
+   [InlineData("$42")]
+   [InlineData("42GBP")]
+   [InlineData("42-")]
+   [InlineData("(42)")]
+   [InlineData(" 42")]
+   [InlineData("42 ")]
+   [InlineData(" 42 ")]
+   [InlineData("   ")]
+   [InlineData("42,000")]
+   [InlineData("42E-3")]
+   [InlineData("+42")]
+   [InlineData("-42")]
+   [InlineData("42.42")]
+   [InlineData("123.4567")]
+   [InlineData("-123.456")]
+   public void SequenceIDField_Parse_ShouldReturnNotPresentInstance_WhenFieldContainsAnInvalidIntegerValue(String fieldContents)
+   {
+      // Arrange.
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      // Act.
+      var field = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(SequenceIDField.NotPresent);
+   }
+
+   [Theory]
+   [InlineData("$42")]
+   [InlineData("42GBP")]
+   [InlineData("42-")]
+   [InlineData("(42)")]
+   [InlineData(" 42")]
+   [InlineData("42 ")]
+   [InlineData(" 42 ")]
+   [InlineData("   ")]
+   [InlineData("42,000")]
+   [InlineData("42E-3")]
+   [InlineData("+42")]
+   [InlineData("-42")]
+   [InlineData("42.42")]
+   [InlineData("123.4567")]
+   [InlineData("-123.456")]
+   public void SequenceIDField_Parse_ShouldLogError_WhenFieldContainsAnInvalidIntegerValue(String fieldContents)
+   {
+      // Arrange.
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(
+         Messages.InvalidNumericValue,
+         _fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         fieldContents);
+
+      // Act.
+      _ = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldTruncateValue_WhenFieldIsLongerThanMaxLength()
+   {
+      // Arrange.
+      var fieldContents = "123456";
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var expectedValue = 1234;
+      var expected = new SequenceIDField(expectedValue);
+
+      // Act.
+      var field = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(expected);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldLogExpectedEntry_WhenFieldIsLongerThanMaxLength()
+   {
+      // Arrange.
+      var fieldContents = "123456";
+      var line = $"TST|{fieldContents}|This is a test...|This is only a test...".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(
+         Messages.LogFieldPresentButTruncated,
+         _fieldSpecification.FieldDescription,
+         _fieldSpecification.Length);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Warning,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         fieldContents);
+
+      // Act.
+      _ = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Theory]
+   [InlineData(Optionality.Optional)]
+   [InlineData(Optionality.Required)]
+   public void SequenceIDField_Parse_ShouldReturnNotPresentInstance_WhenFieldIsBeyondEndOfSuppliedFields(Optionality optionality)
+   {
+      // Arrange.
+      var line = "TST|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+      var fieldSpecification = _fieldSpecification with { Optionality = optionality, Sequence = 2 };
+
+      // Act.
+      var field = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(SequenceIDField.NotPresent);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldLogFieldNotPresent_WhenOptionalFieldIsBeyondEndOfSuppliedFields()
+   {
+      // Arrange.
+      var line = "TST|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+      var fieldSpecification = _fieldSpecification with { Optionality = Optionality.Optional, Sequence = 2 };
+
+      var message = String.Format(
+         Messages.LogFieldNotPresent,
+         fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription);
+
+      // Act.
+      _ = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldLogRequiredFieldNotPresent_WhenRequiredFieldIsBeyondEndOfSuppliedFields()
+   {
+      // Arrange.
+      var line = "TST|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+      var fieldSpecification = _fieldSpecification with { Optionality = Optionality.Required, Sequence = 2 };
+
+      var message = String.Format(
+         Messages.LogRequiredFieldNotPresent,
+         fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription);
+
+      // Act.
+      _ = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Theory]
+   [InlineData(Optionality.Optional)]
+   [InlineData(Optionality.Required)]
+   public void SequenceIDField_Parse_ShouldReturnNotPresentInstance_WhenFieldIsEmpty(Optionality optionality)
+   {
+      // Arrange.
+      var line = "TST||This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+      var fieldSpecification = _fieldSpecification with { Optionality = optionality };
+
+      // Act.
+      var field = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(SequenceIDField.NotPresent);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldLogFieldNotPresent_WhenOptionalFieldIsEmpty()
+   {
+      // Arrange.
+      var line = "TST||This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(
+         Messages.LogFieldNotPresent,
+         _fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription);
+
+      // Act.
+      _ = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldLogRequiredFieldNotPresent_WhenRequiredFieldIsEmpty()
+   {
+      // Arrange.
+      var line = "TST||This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var fieldSpecification = _fieldSpecification with { Optionality = Optionality.Required };
+      var message = String.Format(
+         Messages.LogRequiredFieldNotPresent,
+         fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Error,
+         message,
+         _lineNumber,
+         fieldSpecification.FieldDescription);
+
+      // Act.
+      _ = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldReturnPresentButNullInstance_WhenFieldIsTwoDoubleQuotes()
+   {
+      // Arrange.
+      var line = "TST|\"\"|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      // Act.
+      var field = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      field.Should().Be(SequenceIDField.PresentButNull);
+   }
+
+   [Fact]
+   public void SequenceIDField_Parse_ShouldLogFieldPresentButNull_WhenFieldIsTwoDoubleQuotes()
+   {
+      // Arrange.
+      var line = "TST|\"\"|This is a test..".AsSpan();
+      var fieldEnumerator = line.ToFields(_encodingDetails.FieldSeparator, _encodingDetails.EscapeCharacter);
+      fieldEnumerator.MoveNext();
+      var log = new ProcessingLog();
+
+      var message = String.Format(
+         Messages.LogFieldPresentButNull,
+         _fieldSpecification.FieldDescription);
+      var expectedLogEntry = new LogEntry(
+         LogLevel.Information,
+         message,
+         _lineNumber,
+         _fieldSpecification.FieldDescription,
+         GeneralConstants.PresentButNullValue);
+
+      // Act.
+      _ = SequenceIDField.Parse(
+         ref fieldEnumerator,
+         _fieldSpecification,
+         _lineNumber,
+         log);
+
+      // Assert.
+      log.Should().HaveCount(1);
+      log.First().Should().Be(expectedLogEntry);
+   }
+
+   #endregion
+}

--- a/Tests/HL7.Net.Tests.Unit/Core/SpanExtensionsTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/SpanExtensionsTests.cs
@@ -205,4 +205,46 @@ public class SpanExtensionsTests
    }
 
    #endregion
+
+   #region IsPresentButNull Method Tests
+   // ==========================================================================
+   // ==========================================================================
+
+   [Fact]
+   public void SpanExtensions_IsPresentButNull_ShouldReturnTrue_WhenSpanOnlyContainsTwoDoubleQuoteCharacters()
+   {
+      // Arrange.
+      var span = GeneralConstants.PresentButNullValue.AsSpan();
+
+      // Act/assert.
+      span.IsPresentButNull().Should().BeTrue();
+   }
+
+   [Theory]
+   [InlineData(null)]
+   [InlineData("")]
+   public void SpanExtensions_IsPresentButNull_ShouldReturnFalse_WhenSpanIsEmpty(String fieldContents)
+   {
+      // Arrange.
+      var span = fieldContents.AsSpan();
+
+      // Act/assert.
+      span.IsPresentButNull().Should().BeFalse();
+   }
+
+   [Theory]
+   [InlineData("asdf")]
+   [InlineData("a")]
+   [InlineData("\"")]
+   [InlineData("\"\"asdf")]
+   public void SpanExtensions_IsPresentButNull_ShouldReturnFalse_WhenSpanNonEmptyIsNoPresentButNullIndicator(String fieldContents)
+   {
+      // Arrange.
+      var span = fieldContents.AsSpan();
+
+      // Act/assert.
+      span.IsPresentButNull().Should().BeFalse();
+   }
+
+   #endregion
 }

--- a/Tests/HL7.Net.Tests.Unit/Core/StringFieldTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/Core/StringFieldTests.cs
@@ -34,6 +34,20 @@ public class StringFieldTests
       sut.FieldPresence.Should().Be(FieldPresence.Present);
    }
 
+   [Fact]
+   public void StringField_Constructor_ShouldCreateObject_WhenStringValueAndFieldPresenceAreSupplied()
+   {
+      var value = "asdf";
+
+      // Act.
+      var sut = new StringField(value, FieldPresence.NotPresent);
+
+      // Assert.
+      sut.Should().NotBeNull();
+      sut.Value.Should().Be(value);
+      sut.FieldPresence.Should().Be(FieldPresence.NotPresent);
+   }
+
    #endregion
 
    #region Implicit String Converter Tests
@@ -468,7 +482,7 @@ public class StringFieldTests
    }
 
    [Fact]
-   public void StringField_Parse_ShouldLogPresentButNull_WhenFieldIsTwoDoubleQuotes()
+   public void StringField_Parse_ShouldLogFieldPresentButNull_WhenFieldIsTwoDoubleQuotes()
    {
       // Arrange.
       var line = "TST|\"\"|This is a test..".AsSpan();
@@ -479,13 +493,12 @@ public class StringFieldTests
       var message = String.Format(
          Messages.LogFieldPresentButNull,
          _fieldSpecification.FieldDescription);
-      var rawData = "\"\"";
       var expectedLogEntry = new LogEntry(
          LogLevel.Information,
          message,
          _lineNumber,
          _fieldSpecification.FieldDescription,
-         rawData);
+         GeneralConstants.PresentButNullValue);
 
       // Act.
       _ = StringField.Parse(

--- a/Tests/HL7.Net.Tests.Unit/GlobalUsings.cs
+++ b/Tests/HL7.Net.Tests.Unit/GlobalUsings.cs
@@ -1,9 +1,8 @@
 global using FluentAssertions;
 
 global using HL7.Net.Core;
+global using HL7.Net.Tests.Unit.TestData;
+global using HL7.Net.V2Point2;
 global using HL7.Net.Validation;
 
-global using HL7.Net.Tests.Unit.TestData;
-
 global using Xunit;
-global using Xunit.Abstractions;

--- a/Tests/HL7.Net.Tests.Unit/V2Point2/HL7MessageTests.cs
+++ b/Tests/HL7.Net.Tests.Unit/V2Point2/HL7MessageTests.cs
@@ -1,6 +1,4 @@
-﻿using HL7.Net.V2Point2;
-
-namespace HL7.Net.Tests.Unit.V2Point2;
+﻿namespace HL7.Net.Tests.Unit.V2Point2;
 
 public class HL7MessageTests
 {


### PR DESCRIPTION
# S0006-NumericDatatype

As a developer who uses HL7.Net, I want the HL7 NM and SI datatypes to be fully supported
when parsing messages.

## Requirements

- NumericField class and SequenceIDField class that implement NM datatype as per HL7 V2.2 spec section 2.8.10.4 and 2.8.10.12

## Definition of DONE

1. NumericField class
2. Unit tests for NumericField method
3. SequenceIDField class
4. Unit tests for SequenceIDField method